### PR TITLE
"hashring" -> "hash_ring"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name" : "hashring",
+  "name" : "hash_ring",
   "version" : "0.1.0",
   "description" : "Consistent hashing based on libketama",
   "author": "Brian Noguchi",


### PR DESCRIPTION
Given that you have to require("hash_ring"), I thought it would be better to name the module that rather than "hashring".
