### PR TITLE
Added node-gyp build system, and version bumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ Via npm:
 Via git:
 
     git clone http://github.com/bnoguchi/node-hash-ring.git
+
+    #### node < 0.8.0
     cd node-hash-ring/src
     node-waf configure build
+
+    #### node >= 0.8.0
+    cd node-hash-ring
+    node-gyp configure build
 
 ### Example
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "target_name": "hash_ring",
+      "sources": [
+        'src/md5.cc',
+        'src/hash_ring.cc',
+        'src/module.cc'
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "hash_ring",
-  "version" : "0.2.1",
+  "version" : "0.2.2",
   "description" : "Consistent hashing C++ Add-on for node.js",
   "keywords": [ "node", "hash ring", "consistent hashing", "sharding", "distributed" ],
   "author": "Brian Noguchi <brian.noguchi@gmail.com>",


### PR DESCRIPTION
I added the node-gyp build system for node >= 0.8.0 and version bumped so you can update in npm.  Also, I updated the Readme.md with instructions for those on newer versions of node.  Feel free to tweak as you see fit.

Tested on Mac, FreeBSD, and Linux.  You may want to test on Windows too.

So far, runs good.  Thanks for the hard work. :)
