### PR TITLE
Fixed compatibility with python-hash_ring==1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 See this [blog post](http://ngchi.wordpress.com/2010/08/23/towards-auto-sharding-in-your-node-js-app/) for more information.
 
+This module produces consistent output with [python-hash_ring==1.2](https://github.com/Doist/hash_ring).
+
+
 ### Installation
 Via npm:
 
@@ -41,3 +44,6 @@ MIT License
 ---
 ### Author
 Brian Noguchi
+
+### Contributor
+Krzysztof Dorosz (compatibility with the python-hash_ring module)

--- a/src/hash_ring.cc
+++ b/src/hash_ring.cc
@@ -17,14 +17,14 @@ void HashRing::hash_digest(char *in, unsigned char out[16]) {
     md5_finish(&md5_state, out);
 };
 
-unsigned long int HashRing::hash_val(char *in) {
+unsigned int HashRing::hash_val(char *in) {
     unsigned char digest[16];
     hash_digest(in, digest);
-    return (unsigned long int) (
-        (((unsigned long int) digest[3]) << 24) |
-        (((unsigned long int) digest[2]) << 16) |
-        (((unsigned long int) digest[1]) << 8) |
-         ((unsigned long int) digest[0])
+    return (unsigned int) (
+        (digest[3] << 24) |
+        (digest[2] << 16) |
+        (digest[1] << 8) |
+         digest[0]
     );
 }
 
@@ -47,11 +47,11 @@ HashRing::HashRing(Local<Object> weight_hash) : ObjectWrap() {
     Local<Array> node_names = weight_hash->GetPropertyNames();
     Local<String> node_name;
     uint32_t weight, weight_total = 0;
-    unsigned long int num_servers = node_names->Length();
+    unsigned int num_servers = node_names->Length();
     
     NodeInfo *node_list = new NodeInfo[num_servers];
     // Construct the server list based on the weight hash
-    for (unsigned long int i = 0; i < num_servers; i++) {
+    for (unsigned int i = 0; i < num_servers; i++) {
         NodeInfo *node = &(node_list[i]);
         node_name = node_names->Get(i)->ToString();
         String::Utf8Value utfVal(node_name);
@@ -63,22 +63,22 @@ HashRing::HashRing(Local<Object> weight_hash) : ObjectWrap() {
     }
 
     Vpoint *vpoint_list = new Vpoint[num_servers * 120];
-    unsigned long int j, k;
+    unsigned int j, k;
     int vpoint_idx = 0;
     for (j = 0; j < num_servers; j++) {
         float percent = (float) node_list[j].weight / (float) weight_total;
-        unsigned long int num_replicas = floorf(percent * 40.0 * (float) num_servers);
+        unsigned int num_replicas = floorf(percent * 40.0 * (float) num_servers);
         for (k = 0; k < num_replicas; k++) {
             char ss[30];
-            sprintf(ss, "%s-%ld", node_list[j].id, k);
+            sprintf(ss, "%s-%d", node_list[j].id, k);
             unsigned char digest[16];
             hash_digest(ss, digest);
             int m;
             for (m = 0; m < 3; m++) {
-                vpoint_list[vpoint_idx].point = (((unsigned long int)digest[3 + m*4]) << 24) |
-                                                (((unsigned long int)digest[2 + m*4]) << 16) |
-                                                (((unsigned long int)digest[1 + m*4]) << 8) |
-                                                 ((unsigned long int) digest[m*4]);
+                vpoint_list[vpoint_idx].point = (digest[3 + m*4] << 24) |
+                                                (digest[2 + m*4] << 16) |
+                                                (digest[1 + m*4] <<  8) |
+                                                 digest[m*4];
                 vpoint_list[vpoint_idx].id = node_list[j].id;
                 vpoint_idx++;
             }
@@ -117,12 +117,12 @@ Handle<Value> HashRing::GetNode(const Arguments &args) {
     Local<String> str = args[0]->ToString();
     String::Utf8Value utfVal(str);
     char* key = *utfVal;
-    unsigned long int h = hash_val(key);
+    unsigned int h = hash_val(key);
 
     int high = ring->num_points;
     Vpoint *vpoint_arr = ring->vpoints;
     int low = 0, mid;
-    unsigned long int mid_val, mid_val_1;
+    unsigned int mid_val, mid_val_1;
     while (true)
     {
         mid = (int) ( (low + high) / 2);

--- a/src/hash_ring.cc
+++ b/src/hash_ring.cc
@@ -17,14 +17,14 @@ void HashRing::hash_digest(char *in, unsigned char out[16]) {
     md5_finish(&md5_state, out);
 };
 
-unsigned int HashRing::hash_val(char *in) {
+unsigned long int HashRing::hash_val(char *in) {
     unsigned char digest[16];
     hash_digest(in, digest);
-    return (unsigned int) (
-        (digest[3] << 24) |
-        (digest[2] << 16) |
-        (digest[1] << 8) |
-         digest[0]
+    return (unsigned long int) (
+        (((unsigned long int) digest[3]) << 24) |
+        (((unsigned long int) digest[2]) << 16) |
+        (((unsigned long int) digest[1]) << 8) |
+         ((unsigned long int) digest[0])
     );
 }
 
@@ -47,11 +47,11 @@ HashRing::HashRing(Local<Object> weight_hash) : ObjectWrap() {
     Local<Array> node_names = weight_hash->GetPropertyNames();
     Local<String> node_name;
     uint32_t weight, weight_total = 0;
-    unsigned int num_servers = node_names->Length();
+    unsigned long int num_servers = node_names->Length();
     
     NodeInfo *node_list = new NodeInfo[num_servers];
     // Construct the server list based on the weight hash
-    for (unsigned int i = 0; i < num_servers; i++) {
+    for (unsigned long int i = 0; i < num_servers; i++) {
         NodeInfo *node = &(node_list[i]);
         node_name = node_names->Get(i)->ToString();
         String::Utf8Value utfVal(node_name);
@@ -62,23 +62,23 @@ HashRing::HashRing(Local<Object> weight_hash) : ObjectWrap() {
         weight_total += node->weight;
     }
 
-    Vpoint *vpoint_list = new Vpoint[num_servers * 160];
-    unsigned int j, k;
+    Vpoint *vpoint_list = new Vpoint[num_servers * 120];
+    unsigned long int j, k;
     int vpoint_idx = 0;
     for (j = 0; j < num_servers; j++) {
         float percent = (float) node_list[j].weight / (float) weight_total;
-        unsigned int num_replicas = floorf(percent * 40.0 * (float) num_servers);
+        unsigned long int num_replicas = floorf(percent * 40.0 * (float) num_servers);
         for (k = 0; k < num_replicas; k++) {
             char ss[30];
-            sprintf(ss, "%s-%d", node_list[j].id, k);
+            sprintf(ss, "%s-%ld", node_list[j].id, k);
             unsigned char digest[16];
             hash_digest(ss, digest);
             int m;
-            for (m = 0; m < 4; m++) {
-                vpoint_list[vpoint_idx].point = (digest[3 + m*4] << 24) |
-                                                (digest[2 + m*4] << 16) |
-                                                (digest[1 + m*4] << 8) |
-                                                 digest[m*4];
+            for (m = 0; m < 3; m++) {
+                vpoint_list[vpoint_idx].point = (((unsigned long int)digest[3 + m*4]) << 24) |
+                                                (((unsigned long int)digest[2 + m*4]) << 16) |
+                                                (((unsigned long int)digest[1 + m*4]) << 8) |
+                                                 ((unsigned long int) digest[m*4]);
                 vpoint_list[vpoint_idx].id = node_list[j].id;
                 vpoint_idx++;
             }
@@ -117,12 +117,12 @@ Handle<Value> HashRing::GetNode(const Arguments &args) {
     Local<String> str = args[0]->ToString();
     String::Utf8Value utfVal(str);
     char* key = *utfVal;
-    unsigned int h = hash_val(key);
+    unsigned long int h = hash_val(key);
 
     int high = ring->num_points;
     Vpoint *vpoint_arr = ring->vpoints;
     int low = 0, mid;
-    unsigned int mid_val, mid_val_1;
+    unsigned long int mid_val, mid_val_1;
     while (true)
     {
         mid = (int) ( (low + high) / 2);

--- a/src/hash_ring.h
+++ b/src/hash_ring.h
@@ -7,7 +7,7 @@
 typedef int (*compfn)(const void*, const void*);
 
 typedef struct {
-    unsigned long int point;
+    unsigned int point;
     char* id;
 } Vpoint;
 
@@ -36,7 +36,7 @@ class HashRing : public node::ObjectWrap {
 
   private:
     static void hash_digest(char *in, unsigned char out[16]);
-    static unsigned long int hash_val(char *in);
+    static unsigned int hash_val(char *in);
     static int vpoint_compare(Vpoint *a, Vpoint *b);
 };
 

--- a/src/hash_ring.h
+++ b/src/hash_ring.h
@@ -7,7 +7,7 @@
 typedef int (*compfn)(const void*, const void*);
 
 typedef struct {
-    unsigned int point;
+    unsigned long int point;
     char* id;
 } Vpoint;
 
@@ -36,7 +36,7 @@ class HashRing : public node::ObjectWrap {
 
   private:
     static void hash_digest(char *in, unsigned char out[16]);
-    static unsigned int hash_val(char *in);
+    static unsigned long int hash_val(char *in);
     static int vpoint_compare(Vpoint *a, Vpoint *b);
 };
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,5 @@
+test:
+	cd .. && node-waf configure build
+	node test.js > test.js.txt
+	python test.py > test.py.txt
+	diffstat test.js.txt test.py.txt

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,13 @@
+var HashRing = require("../index");
+var ring = new HashRing({
+    '0.0.0.1' : 1,
+    '0.0.0.2' : 2,
+    '0.0.0.3' : 3,
+    '0.0.0.4' : 4,
+    '0.0.0.5' : 5
+});
+
+
+for (var i=0; i < 100000; i++){
+    console.log(i + ' ' + ring.getNode(i));
+}

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,14 @@
+from hash_ring import HashRing
+
+weights = {
+    '0.0.0.1': 1,
+    '0.0.0.2': 2,
+    '0.0.0.3': 3,
+    '0.0.0.4': 4,
+    '0.0.0.5': 5
+
+}
+
+ring = HashRing(weights.keys(), weights)
+for i in xrange(0,100000):
+    print i, ring.get_node(str(i))


### PR DESCRIPTION
Submitted code is reported to be compatibile with this code: https://github.com/Doist/hash_ring

There was a problem of variable overflow with bit left shift made on small integer.  I automatically replace all `unsigned int` to `unsigned long int`, also in places where it was not really necessary, but I did just left it as it is, as it does not introduces any significant memory usage.

The second problem was in incorrect number of for-loop, which generates virtual nodes. Pythonic `xrange(0,3)` returns `[0, 1, 2]` which translates to `for ( m=0; m < 3; m ++)`.
